### PR TITLE
Pin pygptj Dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         'Source': 'https://github.com/nomic-ai/pygpt4all',
         'Tracker': 'https://github.com/nomic-ai/pygpt4all/issues',
     },
-    install_requires=["pyllamacpp", "pygptj"],
+    install_requires=["pyllamacpp", "pygptj>=2.0.1"],
 )


### PR DESCRIPTION
If using pygptj < 2.0, It gives the following error:
```
ImportError: generic_type: type "gptj_gpt_params" is already registered!
```