### PR TITLE
Fix description text for log_level for both models and fix bug in example usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,21 @@
 # PyGPT4All
+
 Official Python CPU inference for [GPT4All](https://github.com/nomic-ai/gpt4all) language models based on [llama.cpp](https://github.com/ggerganov/llama.cpp) and [ggml](https://github.com/ggerganov/ggml)
 
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![PyPi version](https://badgen.net/pypi/v/pygpt4all)](https://pypi.org/project/pygpt4all/)
 
 <!-- TOC -->
-* [Installation](#installation)
-* [Tutorial](#tutorial)
-    * [Model instantiation](#model-instantiation)
-    * [Simple generation](#simple-generation)
-    * [Interactive Dialogue](#interactive-dialogue)
-* [API reference](#api-reference)
-* [License](#license)
+
+- [Installation](#installation)
+- [Tutorial](#tutorial)
+  - [Model instantiation](#model-instantiation)
+  - [Simple generation](#simple-generation)
+  - [Interactive Dialogue](#interactive-dialogue)
+- [API reference](#api-reference)
+- [License](#license)
 <!-- TOC -->
+
 # Installation
 
 ```bash
@@ -24,8 +27,10 @@ pip install pygpt4all
 You will need first to download the model weights, you can find and download all the supported models from [here](https://github.com/nomic-ai/gpt4all-chat#manual-download-of-models).
 
 ### Model instantiation
+
 Once the weights are downloaded, you can instantiate the models as follows:
-* GPT4All model
+
+- GPT4All model
 
 ```python
 from pygpt4all import GPT4All
@@ -33,7 +38,7 @@ from pygpt4all import GPT4All
 model = GPT4All('path/to/ggml-gpt4all-l13b-snoozy.bin')
 ```
 
-* GPT4All-J model
+- GPT4All-J model
 
 ```python
 from pygpt4all import GPT4All_J
@@ -41,8 +46,8 @@ from pygpt4all import GPT4All_J
 model = GPT4All_J('path/to/ggml-gpt4all-j-v1.3-groovy.bin')
 ```
 
-
 ### Simple generation
+
 The `generate` function is used to generate new tokens from the `prompt` given as input:
 
 ```python
@@ -51,12 +56,13 @@ for token in model.generate("Tell me a joke ?\n"):
 ```
 
 ### Interactive Dialogue
+
 You can set up an interactive dialogue by simply keeping the `model` variable alive:
 
 ```python
 while True:
     try:
-        prompt = input("You: ", flush=True)
+        prompt = input("You: ")
         if prompt == '':
             continue
         print(f"AI:", end='')
@@ -68,9 +74,9 @@ while True:
 ```
 
 # API reference
+
 You can check the [API reference documentation](https://nomic-ai.github.io/pygpt4all/) for more details.
 
-
 # License
-This project is licensed under the MIT  [License](./LICENSE).
 
+This project is licensed under the MIT [License](./LICENSE).

--- a/pygpt4all/models/gpt4all.py
+++ b/pygpt4all/models/gpt4all.py
@@ -49,7 +49,7 @@ class GPT4All(pyllamacpp.model.Model):
         :param prompt_context: the global context of the interaction
         :param prompt_prefix: the prompt prefix
         :param prompt_suffix: the prompt suffix
-        :param log_level: logging level, set to INFO by default
+        :param log_level: logging level, set to ERROR by default
         :param n_ctx: LLaMA context
         :param seed: random seed
         :param n_parts: LLaMA n_parts

--- a/pygpt4all/models/gpt4all_j.py
+++ b/pygpt4all/models/gpt4all_j.py
@@ -40,7 +40,7 @@ class GPT4All_J(pygptj.model.Model):
         :param prompt_context: the global context of the interaction
         :param prompt_prefix: the prompt prefix
         :param prompt_suffix: the prompt suffix
-        :param log_level: logging level
+        :param log_level: logging level, set to ERROR by default
         """
         # set logging level
         set_log_level(log_level)


### PR DESCRIPTION
Currently, the docs website states that the default logging level is set to INFO for the GPT4All model, however, the default log level is actually set to ERROR. This has been updated.

There is also an inconsistency where the same message is not displayed for the GPT4All_J model. This has also been updated. 